### PR TITLE
Add `--svelte5` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ dist
 default
 mini
 maxi
+svelte5
 
 # Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode,macos,windows,node,yarn
 # Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode,macos,windows,node,yarn

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-svelte-with-args",
-  "version": "5.0.0",
+  "version": "4.1.1",
   "description": "A small CLI wrapper around the create-svelte package that enables you to replace the interactive prompts with CLI arguments.",
   "bin": "dist/bin.js",
   "repository": "git@github.com:storybookjs/create-svelte-with-args.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-svelte-with-args",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "description": "A small CLI wrapper around the create-svelte package that enables you to replace the interactive prompts with CLI arguments.",
   "bin": "dist/bin.js",
   "repository": "git@github.com:storybookjs/create-svelte-with-args.git",
@@ -16,11 +16,12 @@
     "build": "tsup",
     "prestart": "yarn build",
     "start": "node ./dist/bin.js",
-    "start:default": "yarn start --name=default --template=default --types=checkjs --no-prettier --no-eslint --no-playwright --no-vitest",
-    "start:mini": "yarn start --name=mini --template=skeleton --types=null --no-prettier --no-eslint --no-playwright --no-vitest",
-    "start:maxi": "yarn start --name=maxi --template=default --types=typescript --prettier --eslint --playwright --vitest",
+    "start:default": "yarn start --name=default --template=default --types=checkjs --no-prettier --no-eslint --no-playwright --no-vitest --no-svelte5",
+    "start:mini": "yarn start --name=mini --template=skeleton --types=null --no-prettier --no-eslint --no-playwright --no-vitest --no-svelte5",
+    "start:maxi": "yarn start --name=maxi --template=default --types=typescript --prettier --eslint --playwright --vitest --no-svelte5",
+    "start:svelte5": "yarn start --name=svelte5 --template=default --types=typescript --prettier --eslint --playwright --vitest --svelte5",
     "start:dry": "yarn start:default --dry",
-    "start:all": "yarn start:default && yarn start:mini && yarn start:maxi && yarn start:dry",
+    "start:all": "yarn start:default && yarn start:mini && yarn start:maxi && yarn start:svelte5 && yarn start:dry",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "type-check": "tsc --noEmit",
@@ -36,7 +37,7 @@
     "yarn": ">=1.3.2"
   },
   "dependencies": {
-    "create-svelte": "5.1.1",
+    "create-svelte": "5.3.1",
     "yargs": "^17.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "yarn": ">=1.3.2"
   },
   "dependencies": {
-    "create-svelte": "5.3.1",
+    "create-svelte": "5.3.2",
     "yargs": "^17.5.1"
   },
   "devDependencies": {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -9,11 +9,11 @@ const main = async () => {
     .epilog('For more information, see https://github.com/storybookjs/create-svelte-with-args')
     .example([
       [
-        'npm create svelte-with-args@latest --name=my-new-app --template=default --types=checkjs --prettier --no-eslint --no-playwright --no-vitest',
+        'npm create svelte-with-args@latest --name=my-new-app --template=default --types=checkjs --prettier --no-eslint --no-playwright --no-vitest --no-svelte5',
         'Default app, checking JS types, with Prettier, and no ESLint, Playwright or Vitest',
       ],
       [
-        'npm create svelte-with-args@latest --name=my-new-app --directory=other-dir/my-app --template=default --types=typescript --no-prettier --no-eslint --no-playwright --no-vitest',
+        'npm create svelte-with-args@latest --name=my-new-app --directory=other-dir/my-app --template=default --types=typescript --no-prettier --no-eslint --no-playwright --no-vitest --no-svelte5',
         'Default app, installing in specified directory',
       ],
     ])
@@ -67,6 +67,12 @@ const main = async () => {
         description: 'Whether vitest should be included',
         demandOption: true,
       },
+      svelte5: {
+        alias: '5',
+        type: 'boolean',
+        description: 'If Svelte 5 beta should be used',
+        demandOption: true,
+      },
       dry: {
         type: 'boolean',
         description: 'Whether to run in dry run mode, not creating any files',
@@ -93,6 +99,7 @@ Will call create-svelte with the following arguments:
     eslint: ${argv.eslint},
     playwright: ${argv.playwright},
     vitest: ${argv.vitest},
+    svelte5: ${argv.svelte5},
   });`);
     return;
   }
@@ -105,6 +112,7 @@ Will call create-svelte with the following arguments:
     eslint: argv.eslint,
     playwright: argv.playwright,
     vitest: argv.vitest,
+    svelte5: argv.svelte5,
   });
 
   console.log(`Done. Succesfully created a new Svelte project in ./${argv.directory}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,7 +1423,7 @@ __metadata:
     "@types/node": ^18.7.23
     "@types/yargs": ^17.0.13
     auto: ^10.37.6
-    create-svelte: 5.3.1
+    create-svelte: 5.3.2
     prettier: ^2.7.1
     tsup: ^6.2.3
     typescript: ^4.8.4
@@ -1433,15 +1433,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"create-svelte@npm:5.3.1":
-  version: 5.3.1
-  resolution: "create-svelte@npm:5.3.1"
+"create-svelte@npm:5.3.2":
+  version: 5.3.2
+  resolution: "create-svelte@npm:5.3.2"
   dependencies:
     "@clack/prompts": ^0.7.0
     kleur: ^4.1.5
   bin:
     create-svelte: bin.js
-  checksum: 242af0dcb794df5f94aaf9d2ad28df8d8cc6dc9183235e857f18dfa825beef21cf6ed6df455dc999f2e9fec8dd3ef1ef4e5c6a36a1660ca3a5040ec16bf85c97
+  checksum: a8203017bbf1a5a12016a462a0e359d622e76a5e40f92a5c496e1621f1b2c25c96c2d2b18e155bb875a4b023ba80f26224fdc15df297735d49df8f90de781e48
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,7 +1423,7 @@ __metadata:
     "@types/node": ^18.7.23
     "@types/yargs": ^17.0.13
     auto: ^10.37.6
-    create-svelte: 5.1.1
+    create-svelte: 5.3.1
     prettier: ^2.7.1
     tsup: ^6.2.3
     typescript: ^4.8.4
@@ -1433,15 +1433,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"create-svelte@npm:5.1.1":
-  version: 5.1.1
-  resolution: "create-svelte@npm:5.1.1"
+"create-svelte@npm:5.3.1":
+  version: 5.3.1
+  resolution: "create-svelte@npm:5.3.1"
   dependencies:
     "@clack/prompts": ^0.7.0
     kleur: ^4.1.5
   bin:
     create-svelte: bin.js
-  checksum: 7db65b65071c2a58ba3c64ca1719d4f0d04aab95ce93f4435ce6094fe74516ad416c00e4c66040515ec9b55c501bc68915ccdaa2305ff8a1d172ad10b13c34c6
+  checksum: 242af0dcb794df5f94aaf9d2ad28df8d8cc6dc9183235e857f18dfa825beef21cf6ed6df455dc999f2e9fec8dd3ef1ef4e5c6a36a1660ca3a5040ec16bf85c97
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This adds a new `--svelte5` (and `--no-svelte5`) option to match `create-svelte@5.3.2`.
Given that all options are required, this is a breaking change.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.0.0--canary.45.2d082de.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install create-svelte-with-args@5.0.0--canary.45.2d082de.0
  # or 
  yarn add create-svelte-with-args@5.0.0--canary.45.2d082de.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
